### PR TITLE
Fix xattrs loading

### DIFF
--- a/PySquashfsImage/PySquashfsImage.py
+++ b/PySquashfsImage/PySquashfsImage.py
@@ -912,7 +912,7 @@ class SquashFsImage(_Squashfs_commons):
 		index_bytes = SQUASHFS_XATTR_BLOCK_BYTES(ids)
 		indexes = SQUASHFS_XATTR_BLOCKS(ids)
 		index = []
-		for r in range(0,ids):
+		for r in range(0,indexes):
 			index.append( self.makeInteger(myfile,SQUASHFS_XATTR_BLOCK_BYTES(1)) )
 		bytes = SQUASHFS_XATTR_BYTES(ids)
 		xattr_ids = {}


### PR DESCRIPTION
Only look for `indexes` block indexes, not `ids` block indexes.